### PR TITLE
GATK bundle genome version path construction issue fixed

### DIFF
--- a/bsf/analyses/variant_calling.py
+++ b/bsf/analyses/variant_calling.py
@@ -31,6 +31,7 @@ import os
 import pickle
 import sys
 import warnings
+import json
 from subprocess import Popen
 
 from bsf.analysis import Analysis, Stage
@@ -3878,9 +3879,16 @@ class VariantCallingGATK(Analysis):
                 pickler_path = os.path.join(
                     self.genome_directory,
                     stage_align_lane.name + '_' + paired_reads_name + '.pkl')
+                json_path = os.path.join(
+                    self.genome_directory,
+                    stage_align_lane.name + '_' + paired_reads_name + '.json')
+
                 with open(file=pickler_path, mode='wb') as pickler_file:
                     pickler = pickle.Pickler(file=pickler_file, protocol=pickle.HIGHEST_PROTOCOL)
                     pickler.dump(pickler_dict_align_lane)
+                    
+                with open(file=json_path, mode='w') as json_fh:
+                    json_fh.write(json.dumps(pickler_dict_align_lane, indent=4, sort_keys=True))
 
                 # Create a bsf_run_bwa.py job to run the pickled object.
 

--- a/bsf/standards.py
+++ b/bsf/standards.py
@@ -1178,11 +1178,11 @@ class StandardFilePath(BaseSection):
         """
         file_path = cls.get(option='gatk_bundle')
 
-        if gatk_bundle_version:
-            file_path = os.path.join(file_path, gatk_bundle_version)
-
         if genome_version:
             file_path = os.path.join(file_path, genome_version)
+
+        if gatk_bundle_version:
+            file_path = os.path.join(file_path, gatk_bundle_version)
 
         return cls._prepend_resource(absolute=absolute, file_path=file_path)
 


### PR DESCRIPTION
Traceback (most recent call last):
  File ".../bsfpython/bin/bsf_submit_variant_calling.py", line 64, in <module>
    analysis.run()
  File ".../bsfpython/bsf/analyses/variant_calling.py", line 3560, in run
    raise Exception('The file path ' + repr(self.bwa_genome_db) +
Exception: The file path '.../resources/GATK/2.8/b37/indices_for_BWA/human_g1k_v37_decoy.fasta' in option 'bwa_genome_db' does not exist.